### PR TITLE
upgrade verifier to fix JSON parsing issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM gradle:jdk11
 
 # Download the plugin verifier.
-RUN curl -L --output /verifier.jar https://dl.bintray.com/jetbrains/intellij-plugin-service/org/jetbrains/intellij/plugins/verifier-cli/1.231/verifier-cli-1.231-all.jar
+RUN curl -L --output /verifier.jar https://dl.bintray.com/jetbrains/intellij-plugin-service/org/jetbrains/intellij/plugins/verifier-cli/1.240/verifier-cli-1.240-all.jar
 
 # Copy and compile the sources of the parser into a jar.
 RUN mkdir /tmp/build-parser


### PR DESCRIPTION
Upgrade IJ plugin verifier to latest [version](https://github.com/JetBrains/intellij-plugin-verifier/releases/tag/v1.240) in order to fix potential JSON parsing issue, as in [this build](https://github.com/jonathanlermitage/intellij-extra-icons-plugin/runs/1045221936?check_suite_focus=true).