### PR TITLE
[#13] Fixed IntelliJ Plugin Verifier binary link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Set the base image.
 FROM gradle:jdk11
 
-# Download the plugin verifier.
-RUN curl -L --output /verifier.jar https://dl.bintray.com/jetbrains/intellij-plugin-service/org/jetbrains/intellij/plugins/verifier-cli/1.252/verifier-cli-1.252-all.jar
-
 # Copy and compile the sources of the parser into a jar.
 RUN mkdir /tmp/build-parser
 COPY src/ /tmp/build-parser

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ steps:
 - uses: thepieterdc/intellij-plugin-verifier-action@v1.3.0
   with:
     plugin: '/path/to/plugin.zip'
+    verifier_version: 1.301
     versions: |
       181.5684.4
       2019.3.3
@@ -50,6 +51,7 @@ jobs:
     - uses: thepieterdc/intellij-plugin-verifier-action@v1.3.0
       with:
         plugin: '/home/runner/work/demo-plugin/demo-plugin/build/distributions/demo-plugin-*'
+        verifier_version: 1.301
         versions: |
           181.5684.4
           2019.3.3

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   plugin:
     description: 'Path to the plugin distribution zip file'
     required: true
+  verifier_version:
+    description: 'The version of the Jetbains IntelliJ Verifier that you want to use'
+    required: true
+    default: '1.301'
   versions:
     description: 'The versions of IntelliJ that should be validated against'
     required: true
@@ -16,4 +20,5 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.plugin }}
+    - ${{ inputs.verifier_version }}
     - ${{ inputs.versions }}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,6 +40,9 @@ ides=$(cat $directories)
 # Write the plugin zips to a file.
 for f in $(echo "$INPUT_PLUGIN"); do echo "$f" >> plugins.txt; done
 
+# Download the Jetbrains' IntelliJ Plugin Verifier
+curl -L --output /verifier.jar "https://packages.jetbrains.team/maven/p/intellij-plugin-verifier/intellij-plugin-verifier/org/jetbrains/intellij/plugins/verifier-cli/$INPUT_VERIFIER_VERSION/verifier-cli-$INPUT_VERIFIER_VERSION-all.jar"
+
 # Execute the verifier.
 echo "Running verifications..."
 verification_log="/tmp/verification.log"


### PR DESCRIPTION
**Hi!**

I found this action on the second page of recommanded IDEs actions on the GitHub Marketplace, but when I tried it, a DNS error occured. I created the issue #13 today, so I decided to fork it and fix it.

# What I did
- Added an "verifier_version" input to let users decide which Plugin Verifier version they want to use 
  - Default value in the action file, to increment at each version
- Moved the download of the Plugin Verifier from the image Dockerfile to the image entrypoint (to get  the version input from environment variables)
- Changed the README in order to explain users how to change their Verifier version

I had already tried it on one of my projects, but you can try it by yourself if you have an IntelliJ plugin
The link that I used is the official link that Jetbrains offer on their repository: https://github.com/JetBrains/intellij-plugin-verifier#installation
Hope that it'll help you (and that it can help me to use your action too!)